### PR TITLE
Skip responses with bad error codes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+__pycache__

--- a/custom_components/CryptoTrakcer/const.py
+++ b/custom_components/CryptoTrakcer/const.py
@@ -9,10 +9,10 @@ CONF_COMPARE = "compare"
 
 ICON = "mdi:cash-multiple"
 
-DEFAULT_SCAN_INTERVAL = timedelta(seconds=120)
+DEFAULT_SCAN_INTERVAL = timedelta(seconds=60)
 
 ATTRIBUTION = "Data provided by cryptonator api"
 
 DEFAULT_COMPARE = "doge-eur"
 
-DOMAIN = "cryptostate"
+DOMAIN = "cryptotracker"

--- a/custom_components/CryptoTrakcer/sensor.py
+++ b/custom_components/CryptoTrakcer/sensor.py
@@ -45,17 +45,16 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend({
     )
 })
 
-
 def get_data(compare):
     """Get The request from the api"""
 
     parsed_url = URL.format(compare)
     #The headers are used to simulate a human request
     headers = {'User-Agent': 'Mozilla/5.0 (X11; Linux x86_64; rv:96.0) Gecko/20100101 Firefox/96.0'}
+
     req = ""
     try:
         req = requests.get(parsed_url, headers=headers, timeout=10)
-        req.raise_for_status()
     except Exception as e:
         _LOGGER.error(e)
 
@@ -69,11 +68,11 @@ def get_data(compare):
         if (resp_parsed["success"]):
             return resp_parsed["ticker"]["price"]
         else:
-            _LOGGER.warning("Recivied an error in the ticker")
+            _LOGGER.warning("Recivied an error in the ticker, if the issue persist consider to open a ticket")
             _LOGGER.error(resp_parsed["error"])
-            return resp_parsed["error"]
+            return False
     else:
-        _LOGGER.error(f"Request returned a bad error code {req.status_code}")
+        return False
 
 def parse_unit_of_mesurament(compare):
     """Parse the input for the unit of mesurament"""
@@ -82,7 +81,6 @@ def parse_unit_of_mesurament(compare):
 
     return s[1].upper()
 
-# See https://github.com/custom-components/feedparser/blob/master/custom_components/feedparser/sensor.py
 async def async_setup_platform(hass, config, async_add_entities, discovery_info=None):
     """Setup the currency sensor"""
 
@@ -144,4 +142,9 @@ class CurrencySensor(SensorEntity):
     def _update(self):
         """Get the latest update fron the api"""
 
-        self._state = get_data(self._compare)
+        data = get_data(self._compare)
+
+        if data != False:
+            self._state = data
+        else: 
+            return False


### PR DESCRIPTION
## Error

According to [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/429) the header of a 429 error
code response shuld contain a parameter like `Retry-After: 3600` that indicates the time to wait before performing another request.

But in the header of the api there is no parameter like this, so we dont know how much time wait before we culd perform another request.

The header of the request with bad error code: 

```json
{
   "Date":"Thu, 03 Feb 2022 17:23:53 GMT",
   "Content-Type":"text/html",
   "Transfer-Encoding":"chunked",
   "Connection":"keep-alive",
   "CF-Cache-Status":"DYNAMIC",
   "Expect-CT":"max-age=604800, report-uri=\"https://report-uri.cloudflare.com/cdn-cgi/beacon/expect-ct\"",
   "Server":"cloudflare",
   "CF-RAY":"6d7d5980da0ad43b-BUD"
}
```

## How i resolved (at least i tryed)

So instead of waiting before performing antoher request, i created a bypass when the request return a bad error code.

**The sensor will update it's state only if the request code is right.**

