### PR TITLE
Fix deprecation warning for async_forward_entry_setup

### DIFF
--- a/custom_components/cryptostate/__init__.py
+++ b/custom_components/cryptostate/__init__.py
@@ -14,7 +14,7 @@ from .const import CONF_BASE, CONF_CRYPTO, DOMAIN
 SCAN_INTERVAL = timedelta(hours=3)
 
 _LOGGER: logging.Logger = logging.getLogger(__package__)
-
+PLATFORMS = ["sensor"]
 
 async def async_setup(hass: HomeAssistant, config: Config):
     """Set this integration using YAML is not supported."""
@@ -43,9 +43,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
 
     if entry.options.get("sensor", True):
         coordinator.platforms.append("sensor")
-        hass.async_add_job(
-            hass.config_entries.async_forward_entry_setup(entry, "sensor")
-        )
+        await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     entry.async_on_unload(entry.add_update_listener(async_reload_entry))
     return True


### PR DESCRIPTION
async_forward_entry_setups is scheduled to be removed in the release 2025.4. There is still time, but I wanted to clean-up my logs :-) 
It also fixes the open issue https://github.com/BigNocciolino/CryptoTracker/issues/40